### PR TITLE
iframe flash while loading

### DIFF
--- a/xdm.js
+++ b/xdm.js
@@ -291,7 +291,9 @@
             style: {
                 margin: 0,
                 padding: 0,
-                border: 0
+                border: 0,
+                position: 'absolute',
+                top: '-9999em'
             }
         });
 


### PR DESCRIPTION
Move iframe out of the normal browser view, this way when all resources are still loading you don't have the problem of a white iframe flashing