### PR TITLE
Guard against frame removal

### DIFF
--- a/xdm.js
+++ b/xdm.js
@@ -531,7 +531,7 @@
                 if (config.isHost) {
                     // add the event handler for listening
                     var waitForReady = function (event) {
-                        if (event.data === config.channel + '-ready') {
+                        if (frame && event.data === config.channel + '-ready') {
                             if ('postMessage' in frame.contentWindow) {
                                 callerWindow = frame.contentWindow;
                             }


### PR DESCRIPTION
`frame` can be null when frames are actively removed. This fix guards against JS errors on the home timeline when scrolling.

See also:
https://github.com/oyvindkinsey/easyXDM/pull/120/files