### PR TITLE
remove support for 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
    - "0.10"
-   - "0.8"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
npm is no longer successfully building v0.8.
Rather than fixing it, we should just drop support for it.