### PR TITLE
Fix ACL checking to be safer for non-regex domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 === HEAD
 
+=== 1.0.4 (March 8, 2016)
+
+* Fix ACL checking to be safer for non-regex domains
+
 === 1.0.2 (March 8, 2016)
 
 * Resolve 'frame is null' errors

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "xdm.js",
     "description": "JSON-RPC 2.0 cross-domain messaging over postMessage",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "main": "xdm.js",
     "ignore": [
         "test",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "xdm.js",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "devDependencies": {
-    "karma": "~0.10.1",
+    "karma": "^0.13.22",
     "karma-jasmine": "~0.1.0",
     "karma-chrome-launcher": "~0.1.0",
     "karma-ie-launcher": "~0.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xdm.js",
   "version": "1.0.4",
   "devDependencies": {
-    "karma": "^0.13.22",
+    "karma": "~0.13.0",
     "karma-jasmine": "~0.1.0",
     "karma-chrome-launcher": "~0.1.0",
     "karma-ie-launcher": "~0.1.1",

--- a/test/spec/xdm.checkAcl.spec.js
+++ b/test/spec/xdm.checkAcl.spec.js
@@ -24,6 +24,10 @@ describe('xdm.checkAcl', function () {
         expect(xdm.checkAcl(acl, 'http://domcccain.com')).toBe(true);
     });
 
+    it('does not match . in string as wildcard', function () {
+        expect(xdm.checkAcl(acl, 'http://godomaina.com')).toBe(false);
+    });
+
     it('does not match', function () {
         expect(xdm.checkAcl(acl, 'http://foo.com')).toBe(false);
     });

--- a/xdm.js
+++ b/xdm.js
@@ -218,7 +218,7 @@
      * @return {String} An escaped regex, with * and ? replaced as regex wildcards
      */
     function escapeRegExp(str) {
-      return str.replace(/[\-\[\]\/\{\}\(\)\+\.\\\^\$\|]/g, "\\$&").replace(/(\*)/g, '.$1').replace(/\?/g, '.');
+      return str.replace(/[-[\]/{}()+.\^$|]/g, "\\$&").replace(/(\*)/g, '.$1').replace(/\?/g, '.');
     }
 
     /**

--- a/xdm.js
+++ b/xdm.js
@@ -212,6 +212,16 @@
     }
 
     /**
+     * Escape string-type ACLs so they can be used as a regex
+     * Manually handles and replaces * and ? since we have a special definition for what those do
+     * @param {String} str A string domain with * or ? as wildcards
+     * @return {String} An escaped regex, with * and ? replaced as regex wildcards
+     */
+    function escapeRegExp(str) {
+      return str.replace(/[\-\[\]\/\{\}\(\)\+\.\\\^\$\|]/g, "\\$&").replace(/(\*)/g, '.$1').replace(/\?/g, '.');
+    }
+
+    /**
      * GUEST ONLY
      * Check whether a host domain is allowed using an Access Control List.
      * The ACL can contain `*` and `?` as wildcards, or can be regular expressions.
@@ -229,9 +239,13 @@
         }
         var re;
         var i = acl.length;
+
         while (i--) {
-            re = acl[i];
-            re = new RegExp(re.substr(0, 1) === '^' ? re : ('^' + re.replace(/(\*)/g, '.$1').replace(/\?/g, '.') + '$'));
+            // According to docs, this should only be treated as regex if it begins with ^ and ends with $.
+            // If it's not regex, we'll process * and ? chars as part of escaping
+            var isRegex = acl[i].substr(0, 1) === '^' && acl[i].substr(acl[i].length - 1, 1) === '$';
+            re = isRegex ? acl[i] : '^' + escapeRegExp(acl[i]) + '$';
+            re = new RegExp(re);
             if (re.test(domain)) {
                 return true;
             }


### PR DESCRIPTION
**Problem**
Currently the documentation reads:

xdmConfig.acl (optional; guest application only)
Add domains to an Access Control List. The ACL can contain * and ? as wildcards, or can be regular expressions. If regular expressions they need to begin with ^ and end with $.

Reading that documentation, it seems to a user there are two options:
1) 'https://*.example.com' should match any subdomain of example.com, treated as a string with */? options mapping to regex.
2) I provide stringy regex '^https://.*\\.twitter\\.com$' and it's treated as regex.

However, in the code, it appears that the string (example 1) is always treated as regex. This means in example one, where I said it should match any sub-domain, it actually matches https://go2example.com as well.

This inadvertent treatment is inconsistent with the documentation and means that a user might input a direct string, and unexpectedly have it treated as regex with unintended consequences.

**Solution**
Match the code to the documentation, requiring that both ^ and $ are actually specified in order to be used as direct regex. Also escape any strings before converting them to regex to reduce mistakes and increase security

NOTE: I also bumped the version and updated karma so that it would run tests on newer versions of node.